### PR TITLE
chore: replace HOSTNAME with AWS_ROLE_SESSION_NAME, change now func and comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ js_set $awsDate                 awssig4.awsHeaderDate;
 js_set $awsPayloadHash          awssig4.awsHeaderPayloadHash;
 js_set $awsSessionToken         awscredentials.sessionToken;
 js_set $lambdaFunctionARNAuth   lambdagateway.lambdaFunctionARNAuth;
+js_var $defaultHostName         'nginx-lambda-gateway';
 
 map $request_uri $lambda_url {
     default  https://lambda.us-east-1.amazonaws.com;
@@ -145,7 +146,7 @@ function lambdaFunctionARNAuth(r) {
     const credentials = awscred.readCredentials(r);
 
     const signature = awssig4.signatureV4(
-        r, awscred.getNow(), region, SERVICE,
+        r, awscred.Now(), region, SERVICE,
         r.variables.request_uri, queryParams, host, credentials
     );
     return signature;

--- a/core/awscredentials.js
+++ b/core/awscredentials.js
@@ -68,8 +68,9 @@ function sessionToken(r) {
 }
 
 /**
- * Get the instance profile credentials needed to authenticate against Lambda from
- * a backend cache. If the credentials cannot be found, then return undefined.
+ * Get the instance profile credentials needed to authenticate against services 
+ * in AWS such as S3 and Lambda from a backend cache. If the credentials cannot
+ * be found, then return undefined.
  * @param r {Request} HTTP request object (not used, but required for NGINX configuration)
  * @returns {undefined|{accessKeyId: (string), secretAccessKey: (string), sessionToken: (string|null), expiration: (string|null)}} AWS instance profile credentials or undefined
  */
@@ -363,14 +364,14 @@ async function _fetchEC2RoleCredentials() {
 
 /**
  * Get the credentials by assuming calling AssumeRoleWithWebIdentity with the environment variable
- * values ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE and HOSTNAME
+ * values ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_SESSION_NAME.
  *
  * @returns {Promise<{accessKeyId: (string), secretAccessKey: (string), sessionToken: (string), expiration: (string)}>}
  * @private
  */
 async function _fetchWebIdentityCredentials(r) {
     const arn = process.env['AWS_ROLE_ARN'];
-    const name = process.env['HOSTNAME'] || 'nginx-lambda-gateway';
+    const name = process.env['AWS_ROLE_SESSION_NAME'];
 
     let sts_endpoint = process.env['STS_ENDPOINT'];
     if (!sts_endpoint) {
@@ -426,12 +427,12 @@ async function _fetchWebIdentityCredentials(r) {
  *
  * @returns {Date} The current moment as a timestamp
  */
-function getNow() {
+function Now() {
     return NOW;
 }
 
 export default {
-    getNow,
+    Now,
     fetchCredentials,
     readCredentials,
     sessionToken,

--- a/core/awssig4.js
+++ b/core/awssig4.js
@@ -29,7 +29,6 @@ const EMPTY_PAYLOAD_HASH = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495
  * Constant defining the headers being signed.
  * @type {string}
  */
-// const DEFAULT_SIGNED_HEADERS = 'host;x-amz-content-sha256;x-amz-date';
 const DEFAULT_SIGNED_HEADERS = 'host;x-amz-date';
 
 /**
@@ -197,8 +196,7 @@ function _buildStringToSign(amzDatetime, eightDigitDate, region, service, canoni
  * @private
  */
 function _signedHeaders(r, sessionToken) {
-    let headers = '';
-    headers += DEFAULT_SIGNED_HEADERS;
+    let headers = DEFAULT_SIGNED_HEADERS;
     if (sessionToken && sessionToken.length > 0) {
         headers += ';x-amz-security-token';
     }
@@ -264,8 +262,8 @@ function _splitCachedValues(cached) {
  */
 function awsHeaderDate(r) {
     return utils.getAmzDatetime(
-        awscred.getNow(),
-        utils.getEightDigitDate(awscred.getNow())
+        awscred.Now(),
+        utils.getEightDigitDate(awscred.Now())
     );
 }
 


### PR DESCRIPTION
### Proposed changes

- Remove a hardcoded default host name in NJS to be used for Role Session Name at multiple services in AWS
- Change now function and comments
- Remove unused comments such as `x-amz-content-sha256` as this doesn't work for Lambda in the signature.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-aws-signature/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-aws-signature/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-aws-signature/blob/main/CHANGELOG.md))
