### PR TITLE
fix: Temporary file written with current user read only. Can run test suite using podman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,7 @@
 
 - Initial release of the `nginx-aws-signature` repository.
 - Compatible with [`nginx-s3-gateway`](https://github.com/nginxinc/nginx-s3-gateway) and [`nginx-lambda-gateway`](https://github.com/nginx-serverless/nginx-lambda-gateway).
+
+## 1.1.0 (9 4, 2024)
+
+- Removed keyval and filestore, replaced with ngx.shared

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ NGINX AWS Signature Library to authenticate AWS services such as S3 and Lambda v
 
 This project is to provide the common library for your apps or services. To get this project up and running, the following nginx project can be used prior to implementing your project.
 
+Requires njs 0.8.0+
+
 - [Getting Started with `nginx-s3-gateway`](https://github.com/nginxinc/nginx-s3-gateway#getting-started)
 - [Getting Started with `nginx-lambda-gateway`](https://github.com/nginx-serverless/nginx-lambda-gateway#getting-started)
 
@@ -95,6 +97,9 @@ js_var $defaultHostName         'nginx-lambda-gateway';
 map $request_uri $lambda_url {
     default  https://lambda.us-east-1.amazonaws.com;
 }
+
+#Create a shared dictionay 'aws' for ngx.shared
+js_shared_dict_zone zone=aws:32k type=string;
 
 server {
     listen 80; # Use SSL/TLS in production

--- a/core/awscredentials.js
+++ b/core/awscredentials.js
@@ -205,7 +205,7 @@ function _writeCredentialsToKeyValStore(r, credentials) {
  * @private
  */
 function _writeCredentialsToFile(credentials) {
-    fs.writeFileSync(_credentialsTempFile(), JSON.stringify(credentials));
+    fs.writeFileSync(_credentialsTempFile(), JSON.stringify(credentials),{mode:0x400});
 }
 
 /**

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -3,10 +3,10 @@ services:
   nginx_aws_signature_test:
     hostname: nginx_aws_signature_test
     container_name: nginx_aws_signature_test
-    image: nginx_aws_signature_test:${NGINX_TYPE}
+    image: nginx_aws_signature_test:${nginx_type}
     build:
       context: ./
-      dockerfile: Dockerfile.${NGINX_TYPE}
+      dockerfile: Dockerfile.${nginx_type}
     volumes:
       - ./build_context/etc/nginx/conf.d:/etc/nginx/conf.d
       - ../../core:/etc/nginx/serverless


### PR DESCRIPTION
### Proposed changes

When writing AWS credentials to a temporary file, the file was world readable. To limit potential exposure this change writes the file as user read only

To get the tests to run under Fedora 38, I had to add a new optional argument to test.sh

--podman

This will use podman, podman-compose instead of docker.

There were additional bugs in the test.sh script

- If missing docker / podman, the error messages were not displayed
- The nginx_type environment variable was not exported and so was not available to the docker-compose.yml file

I have not updated the CHANGELOG.md as it explicitly sets the version number, and I am unsure what version number to use

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-aws-signature/blob/main/CONTRIBUTING.md) document
- [ x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-aws-signature/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-aws-signature/blob/main/CHANGELOG.md))

